### PR TITLE
Comments handling in proof grammar

### DIFF
--- a/src/syntaxes/coq-proof.json
+++ b/src/syntaxes/coq-proof.json
@@ -2,6 +2,7 @@
   "fileTypes": ["v"],
   "name": "Coq proofs",
   "patterns": [
+    { "include": "source.coq#block_comment" },
     { "include": "#proof" }
   ],
   "repository": {

--- a/src/test/syntaxes/comments.test.v
+++ b/src/test/syntaxes/comments.test.v
@@ -20,3 +20,7 @@ Qed.
      forall A B : Prop, A -> B -> A /\ B. *)
 //   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.proof.coq
 // <-------------------------------------------- comment.block.coq - meta.proof.coq
+
+(* Lemma and_intro *) : forall A B : Prop, A -> B -> A /\ B.
+// <--------------------- comment.block.coq - meta.proof.coq
+//                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - comment.block.coq meta.proof.coq

--- a/src/test/syntaxes/comments.test.v
+++ b/src/test/syntaxes/comments.test.v
@@ -1,0 +1,22 @@
+// SYNTAX TEST "source.coq.proof"
+
+Lemma and_intro : forall A B : Prop, A -> B -> A /\ B.
+Proof.
+  intros A B HA HB. split.
+  - apply HA.
+  (* Comment *) - apply HB.
+//^^^^^^^^^^^^^ comment.block.coq
+//              ^^^^^^^^^^^ - comment.block.coq
+Qed.
+
+(* Comment *)
+// <------------- comment.block.coq
+
+(* Lemma and_intro : forall A B : Prop, A -> B -> A /\ B. *)
+// <-------------------------------------------------------------------- comment.block.coq - meta.proof.coq
+
+(* Lemma and_intro : 
+// ^^^^^^^^^^^^^^^^^ - meta.proof.coq
+     forall A B : Prop, A -> B -> A /\ B. *)
+//   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - meta.proof.coq
+// <-------------------------------------------- comment.block.coq - meta.proof.coq


### PR DESCRIPTION
Comments created problems within the proof grammar: a proof was parsed even if it was inside a comment.